### PR TITLE
Bug/yq mismatch ver

### DIFF
--- a/linkfiles/scripts/tg-boilerplate-code.sh
+++ b/linkfiles/scripts/tg-boilerplate-code.sh
@@ -6,6 +6,7 @@ SKELETON_YAML="$BASE_DIR/skeleton.yaml"
 INPUTS_YAML="$BASE_DIR/inputs.yaml"
 COMMON_DIR="$BASE_DIR/common"
 ENV_DIR="$BASE_DIR/env"
+INTERNALS_DIR="$BASE_DIR/internals"
 ACCOUNTS_JSON="$BASE_DIR/accounts.json"
 
 # Function to extract values from a YAML file
@@ -68,6 +69,12 @@ create_hcl_file "$module_file" "$content"
 inputs_file="$INPUTS_YAML"
 content="naming_prefix: $naming_prefix"
 create_hcl_file "$inputs_file" "$content"
+
+# Create internals directory
+if [ ! -d "$INTERNALS_DIR" ]; then
+    echo "Directory '$INTERNALS_DIR' not found. Creating the directory named '$INTERNALS_DIR'."
+    mkdir -p "$INTERNALS_DIR/pipelines"
+fi
 
 # Create subdirectories under the 'env' directory
 if [ ! -d "$ENV_DIR" ]; then

--- a/linkfiles/scripts/tg-boilerplate-code.sh
+++ b/linkfiles/scripts/tg-boilerplate-code.sh
@@ -43,7 +43,7 @@ git_repo_url=$(extract_values "git_repo_url" "$SKELETON_YAML")
 module_file_name=$(extract_values "module_file_name" "$SKELETON_YAML")
 
 # Create accounts.json file
-envs=$(yq '.envs | @json' -r "$SKELETON_YAML")
+envs=$(yq -r .envs $SKELETON_YAML)
 generate_accounts_json "$envs"
 
 # Create subdirectories under the 'env' directory

--- a/linkfiles/scripts/tg-boilerplate-code.sh
+++ b/linkfiles/scripts/tg-boilerplate-code.sh
@@ -30,7 +30,7 @@ generate_accounts_json() {
     local input="$1"
 
     # Use jq to iterate through the input JSON and create key-value pairs
-    accounts_json="$accounts_json$(echo "$input" | jq '{ "envs": . }' | jq -r '.envs[] | to_entries[] | { (.key): .value.aws_profile }' | jq -s 'add')"
+    accounts_json="$accounts_json$(echo "$input" | jq '{ "envs": . }' | jq -r '.envs[] | to_entries[] | { (.key): .value.profile }' | jq -s 'add')"
 
     # Write accounts.json to a file
     echo "$accounts_json" > accounts.json
@@ -95,7 +95,7 @@ for environment in $environments; do
 
         region_hcl_file="$region_dir/region.hcl"
         content="locals {
-  aws_region = \"$region\"
+  env_region = \"$region\"
 }"
         create_hcl_file "$region_hcl_file" "$content"
 

--- a/linkfiles/scripts/tg-properties-boilerplate-code.sh
+++ b/linkfiles/scripts/tg-properties-boilerplate-code.sh
@@ -22,7 +22,7 @@ if [ ! -d "$ENV_DIR" ]; then
     mkdir -p "$ENV_DIR"
 fi
 
-envs=$(yq '.envs | @json' -r "$SKELETON_YAML")
+envs=$(yq -r .envs $SKELETON_YAML)
 
 # Iterate through environments
 environments=$(echo "$envs" | jq '{ "envs": . }' | jq -r '.envs[]? | keys[]')


### PR DESCRIPTION
- There was an issue found where `pip/apt install yq` =/= `brew (mac)`. The one released in the OS package manager is the [Mikefarah](https://github.com/mikefarah/yq) version based on GO. Where as the pip one is [python](https://pypi.org/project/yq/) based written by someone else. By default 22.04 installs yq from the python version. It was decided to use the python-yq version type arguments as it is built upon `jq` and offers TOML support. home bre can install this version by using `brew install python-yq`
- This PR will also change the package name from `caf-component-aws-terragrunt` -> `caf-component-terragrunt` and bumpt to `0.2.1`. This component can be used for multiple providers